### PR TITLE
Auto-discover calendar path based on well-known caldav location

### DIFF
--- a/GroupDAVStore.m
+++ b/GroupDAVStore.m
@@ -136,7 +136,18 @@
 	newURL = [originalURL URLByAppendingPathComponent:homeSetString];
       }
     }
-
+    else {
+      NSRunAlertPanel(@"Unable to find your calendar",
+		      [NSString stringWithFormat:
+				  @"Couldn't parse the response to a get user "
+				@"principle request at %@",
+				wellKnownURL],
+		      @"OK",
+		      nil,
+		      nil);
+      [self updateOK];
+      return;
+    }
   }
   else {
     newURL = originalURL;

--- a/GroupDAVStore.m
+++ b/GroupDAVStore.m
@@ -104,13 +104,7 @@
   [self clearPopUps];
 
   if ([[originalURL path] length] == 0) {
-    id wellKnownURL = [NSURL URLWithString:
-			       [NSString stringWithFormat:
-						     @"%@://%@:%@@%@/.well-known/caldav",
-				  [originalURL scheme],
-				  [originalURL user],
-				  [originalURL password],
-				  [originalURL host]]];
+    id wellKnownURL = [originalURL URLByAppendingPathComponent:@".well-known/caldav"];
     resource = [[WebDAVResource alloc] initWithURL:wellKnownURL];
     NSString *getUserPrincipalBody = @"<?xml version=\"1.0\" encoding=\"utf-8\"?><d:propfind xmlns:d=\"DAV:\"><d:prop><d:current-user-principal/></d:prop></d:propfind>";
     NSString *getCalendarHomeSetBody = @"<?xml version=\"1.0\" encoding=\"utf-8\"?><d:propfind xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\"><d:self/><d:prop><c:calendar-home-set /></d:prop></d:propfind>";
@@ -123,14 +117,7 @@
       id node = [set nodeAtIndex:0];
       id principalString = [node content];
       NSLog(@"principalString: %@", principalString);
-      newURL = [NSURL URLWithString:
-			[NSString stringWithFormat:
-					      @"%@://%@:%@@%@/%@",
-				  [originalURL scheme],
-				  [originalURL user],
-				  [originalURL password],
-				  [originalURL host],
-				  principalString]];
+      newURL = [originalURL URLByAppendingPathComponent:principalString];
       NSLog(@"newURL: %@", newURL);
       resource = [[WebDAVResource alloc] initWithURL:newURL];
       [resource propfind:[getCalendarHomeSetBody dataUsingEncoding:NSUTF8StringEncoding] attributes:[NSDictionary dictionaryWithObject:@"Infinity" forKey:@"Depth"]];
@@ -141,14 +128,7 @@
 	node = [set nodeAtIndex:0];
 	id homeSetString = [node content];
 	NSLog(@"homeSetString: %@", homeSetString);
-	newURL = [NSURL URLWithString:
-			  [NSString stringWithFormat:
-						@"%@://%@:%@@%@/%@",
-				    [originalURL scheme],
-				    [originalURL user],
-				    [originalURL password],
-				    [originalURL host],
-				    homeSetString]];
+	newURL = [originalURL URLByAppendingPathComponent:homeSetString];
       }
     }
 

--- a/GroupDAVStore.m
+++ b/GroupDAVStore.m
@@ -113,6 +113,7 @@
 
   [resource propfind:[getUserPrincipalBody dataUsingEncoding:NSUTF8StringEncoding] attributes:[NSDictionary dictionaryWithObject:@"Infinity" forKey:@"Depth"]];
   parser = [GSXMLParser parserWithData:[resource data]];
+  id newURL = nil;
   if ([parser parse]) {
     xpc = [[GSXPathContext alloc] initWithDocument:[[parser document] strippedDocument]];
     set = (GSXPathNodeSet *)[xpc evaluateExpression:@"(//response/propstat)[1]/prop/current-user-principal/href/text()"];
@@ -120,7 +121,7 @@
     id principalString = [node content];
     NSLog(@"principalString: %@", principalString);
     NSURL *originalURL = [NSURL URLWithString:[url stringValue]];
-    NSURL *newURL = [NSURL URLWithString:
+    newURL = [NSURL URLWithString:
 			     [NSString stringWithFormat:
 						   @"%@://%@:%@@%@/%@",
 				       [originalURL scheme],
@@ -138,12 +139,20 @@
       node = [set nodeAtIndex:0];
       id homeSetString = [node content];
       NSLog(@"homeSetString: %@", homeSetString);
+      newURL = [NSURL URLWithString:
+			     [NSString stringWithFormat:
+						   @"%@://%@:%@@%@/%@",
+				       [originalURL scheme],
+				       [originalURL user],
+				       [originalURL password],
+				       [originalURL host],
+				       homeSetString]];
     }
   }
 
-
-  if ([[url stringValue] isValidURL]) {
-    resource = [[WebDAVResource alloc] initWithURL:[NSURL URLWithString:[url stringValue]]];
+  // re introduce some error handling
+  if (YES) {
+    resource = [[WebDAVResource alloc] initWithURL:newURL];
     if ([resource propfind:[body dataUsingEncoding:NSUTF8StringEncoding] attributes:[NSDictionary dictionaryWithObject:@"Infinity" forKey:@"Depth"]]) {
 
       parser = [GSXMLParser parserWithData:[resource data]];

--- a/GroupDAVStore.m
+++ b/GroupDAVStore.m
@@ -22,6 +22,17 @@
 }
 @end
 
+@interface GroupDAVStore (WellKnownLookups)
+
+- (NSURL*)calendarURLFromRootOfServer:(NSURL *)originalURL
+				error:(NSError **)error;
+- (NSError *)unableToFindCalendarError:(NSString *)message;
+- (NSError *)reportGroupDAVError:(NSString *)title
+			 message:(NSString *)message;
+- (void)reportError:(NSError *)error;
+
+@end
+
 @interface GroupDAVDialog : NSObject
 {
   IBOutlet id panel;

--- a/GroupDAVStore.m
+++ b/GroupDAVStore.m
@@ -101,6 +101,11 @@
   id originalURL = [NSURL URLWithString:[url stringValue]];
   id newURL = nil;
 
+  if (originalURL == nil) {
+    [self updateOK];
+    return;
+  }
+  
   [self clearPopUps];
 
   if ([[originalURL path] length] == 0) {
@@ -136,34 +141,31 @@
   else {
     newURL = originalURL;
   }
-  // re introduce some error handling
-  if (YES) {
-    resource = [[WebDAVResource alloc] initWithURL:newURL];
-    if ([resource propfind:[body dataUsingEncoding:NSUTF8StringEncoding] attributes:[NSDictionary dictionaryWithObject:@"Infinity" forKey:@"Depth"]]) {
+  resource = [[WebDAVResource alloc] initWithURL:newURL];
+  if ([resource propfind:[body dataUsingEncoding:NSUTF8StringEncoding] attributes:[NSDictionary dictionaryWithObject:@"Infinity" forKey:@"Depth"]]) {
 
-      parser = [GSXMLParser parserWithData:[resource data]];
-      if ([parser parse]) {
-	xpc = [[GSXPathContext alloc] initWithDocument:[[parser document] strippedDocument]];
-	set = (GSXPathNodeSet *)[xpc evaluateExpression:@"//response[propstat/prop/resourcetype/vevent-collection]/href/text()"];
-	for (i = 0; i < [set count]; i++)
-	  [calendar addItemWithTitle:[[set nodeAtIndex:i] content]];
-	set = (GSXPathNodeSet *)[xpc evaluateExpression:@"//response[propstat/prop/resourcetype/vtodo-collection]/href/text()"];
-	for (i = 0; i < [set count]; i++)
-	  [task addItemWithTitle:[[set nodeAtIndex:i] content]];
-	set = (GSXPathNodeSet *)[xpc evaluateExpression:@"//response[propstat/prop/resourcetype/calendar]/href/text()"];
-	for (i = 0; i < [set count]; i++) {
-	  [calendar addItemWithTitle:[[set nodeAtIndex:i] content]];
-	  [task addItemWithTitle:[[set nodeAtIndex:i] content]];
-	}
-	RELEASE(xpc);
-	if ([calendar numberOfItems] > 0)
-	  [calendar selectItemAtIndex:1];
-	if ([task numberOfItems] > 0)
-	  [task selectItemAtIndex:1];
+    parser = [GSXMLParser parserWithData:[resource data]];
+    if ([parser parse]) {
+      xpc = [[GSXPathContext alloc] initWithDocument:[[parser document] strippedDocument]];
+      set = (GSXPathNodeSet *)[xpc evaluateExpression:@"//response[propstat/prop/resourcetype/vevent-collection]/href/text()"];
+      for (i = 0; i < [set count]; i++)
+	[calendar addItemWithTitle:[[set nodeAtIndex:i] content]];
+      set = (GSXPathNodeSet *)[xpc evaluateExpression:@"//response[propstat/prop/resourcetype/vtodo-collection]/href/text()"];
+      for (i = 0; i < [set count]; i++)
+	[task addItemWithTitle:[[set nodeAtIndex:i] content]];
+      set = (GSXPathNodeSet *)[xpc evaluateExpression:@"//response[propstat/prop/resourcetype/calendar]/href/text()"];
+      for (i = 0; i < [set count]; i++) {
+	[calendar addItemWithTitle:[[set nodeAtIndex:i] content]];
+	[task addItemWithTitle:[[set nodeAtIndex:i] content]];
       }
+      RELEASE(xpc);
+      if ([calendar numberOfItems] > 0)
+	[calendar selectItemAtIndex:1];
+      if ([task numberOfItems] > 0)
+	[task selectItemAtIndex:1];
     }
-    [resource release];
   }
+  [resource release];
   [self updateOK];
 }
 - (NSString *)url

--- a/GroupDAVStore.m
+++ b/GroupDAVStore.m
@@ -90,6 +90,17 @@
 {
   [self updateOK];
 }
+
+- (void)reportGroupDAVError:(NSString *)title message:(NSString *)message
+{
+  NSRunAlertPanel(title,
+		  message,
+		  @"OK",
+		  nil,
+		  nil);
+  [self updateOK];
+}
+
 - (void)controlTextDidEndEditing:(NSNotification *)aNotification
 {
   int i;
@@ -115,6 +126,15 @@
     NSString *getCalendarHomeSetBody = @"<?xml version=\"1.0\" encoding=\"utf-8\"?><d:propfind xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\"><d:self/><d:prop><c:calendar-home-set /></d:prop></d:propfind>";
 
     [resource propfind:[getUserPrincipalBody dataUsingEncoding:NSUTF8StringEncoding] attributes:[NSDictionary dictionaryWithObject:@"Infinity" forKey:@"Depth"]];
+    if ([resource data] == nil) {
+      [self reportGroupDAVError:@"Unable to find your calendar"
+			message:[NSString stringWithFormat:
+					    @"No data was returned when "
+					  @"trying to find the current user "
+					  @"principal at %@",
+					  wellKnownURL]];
+      return;
+    };
     parser = [GSXMLParser parserWithData:[resource data]];
     if ([parser parse]) {
       xpc = [[GSXPathContext alloc] initWithDocument:[[parser document] strippedDocument]];
@@ -137,15 +157,11 @@
       }
     }
     else {
-      NSRunAlertPanel(@"Unable to find your calendar",
-		      [NSString stringWithFormat:
-				  @"Couldn't parse the response to a get user "
-				@"principle request at %@",
-				wellKnownURL],
-		      @"OK",
-		      nil,
-		      nil);
-      [self updateOK];
+      [self reportGroupDAVError:@"Unable to find your calendar"
+			message:[NSString stringWithFormat:
+					    @"Couldn't parse the response to "
+					  @"a get user principal request at %@",
+					  wellKnownURL]];
       return;
     }
   }

--- a/GroupDAVStore.m
+++ b/GroupDAVStore.m
@@ -98,6 +98,8 @@
   NSString *body = @"<?xml version=\"1.0\" encoding=\"utf-8\"?><propfind xmlns=\"DAV:\"><prop><getlastmodified/><executable/><resourcetype/></prop></propfind>";
   GSXPathContext *xpc;
   GSXPathNodeSet *set;
+  id originalURL = [NSURL URLWithString:[url stringValue]];
+  id newURL = nil;
 
   [self clearPopUps];
 
@@ -107,20 +109,18 @@
   // ask for calendar-home-set
   // that gives calendar home set
   // use that below
-  resource = [[WebDAVResource alloc] initWithURL:[NSURL URLWithString:[url stringValue]]];
+  resource = [[WebDAVResource alloc] initWithURL:originalURL];
   NSString *getUserPrincipalBody = @"<?xml version=\"1.0\" encoding=\"utf-8\"?><d:propfind xmlns:d=\"DAV:\"><d:prop><d:current-user-principal/></d:prop></d:propfind>";
   NSString *getCalendarHomeSetBody = @"<?xml version=\"1.0\" encoding=\"utf-8\"?><d:propfind xmlns:d=\"DAV:\" xmlns:c=\"urn:ietf:params:xml:ns:caldav\"><d:self/><d:prop><c:calendar-home-set /></d:prop></d:propfind>";
 
   [resource propfind:[getUserPrincipalBody dataUsingEncoding:NSUTF8StringEncoding] attributes:[NSDictionary dictionaryWithObject:@"Infinity" forKey:@"Depth"]];
   parser = [GSXMLParser parserWithData:[resource data]];
-  id newURL = nil;
   if ([parser parse]) {
     xpc = [[GSXPathContext alloc] initWithDocument:[[parser document] strippedDocument]];
     set = (GSXPathNodeSet *)[xpc evaluateExpression:@"(//response/propstat)[1]/prop/current-user-principal/href/text()"];
     id node = [set nodeAtIndex:0];
     id principalString = [node content];
     NSLog(@"principalString: %@", principalString);
-    NSURL *originalURL = [NSURL URLWithString:[url stringValue]];
     newURL = [NSURL URLWithString:
 			     [NSString stringWithFormat:
 						   @"%@://%@:%@@%@/%@",

--- a/GroupDAVStore.m
+++ b/GroupDAVStore.m
@@ -100,6 +100,26 @@
   GSXPathNodeSet *set;
 
   [self clearPopUps];
+
+  // url is the thing that the user supplied
+  // get-user-principal on it
+  // that gives user principal
+  // ask for calendar-home-set
+  // that gives calendar home set
+  // use that below
+  resource = [[WebDAVResource alloc] initWithURL:[NSURL URLWithString:[url stringValue]]];
+  NSString *getUserPrincipalBody = @"<?xml version=\"1.0\" encoding=\"utf-8\"?><d:propfind xmlns:d=\"DAV:\"><d:prop><d:current-user-principal/></d:prop></d:propfind>";
+  [resource propfind:[getUserPrincipalBody dataUsingEncoding:NSUTF8StringEncoding] attributes:[NSDictionary dictionaryWithObject:@"Infinity" forKey:@"Depth"]];
+  parser = [GSXMLParser parserWithData:[resource data]];
+  if ([parser parse]) {
+    xpc = [[GSXPathContext alloc] initWithDocument:[[parser document] strippedDocument]];
+    set = (GSXPathNodeSet *)[xpc evaluateExpression:@"(//response/propstat)[1]/prop/current-user-principal/href/text()"];
+    id node = [set nodeAtIndex:0];
+    id principalString = [node content];
+    NSLog(@"principalString: %@", principalString);
+  }
+
+
   if ([[url stringValue] isValidURL]) {
     resource = [[WebDAVResource alloc] initWithURL:[NSURL URLWithString:[url stringValue]]];
     if ([resource propfind:[body dataUsingEncoding:NSUTF8StringEncoding] attributes:[NSDictionary dictionaryWithObject:@"Infinity" forKey:@"Depth"]]) {


### PR DESCRIPTION
This pull request which @srbaker and I collaborated on lets a user type just their server address (e.g. https://user:pass@calendar.example.com) into the GroupDAV store, even if they don't know the path to their calendar. It uses the RFC5785 documented well-known path for the caldav root to discover the user principal, then finds that principal's home calendar set, then finds the calendars for the user to choose.

If the user enters a full URL containing the path to the calendar (e.g. https://user:pass@calendar.example.com/user/calendar), then we don't do any of that, and treat the URL as the location of the calendar, as before. We have tested on Nextcloud 21 and 22.

I appreciate this change makes the `-controlTextDidEndEditing:` method a lot longer, do you think we need to extract some helper methods from that?